### PR TITLE
Fix 5-col transform offset for right peripheral

### DIFF
--- a/app/boards/shields/hillside_view/hillside_view_right.overlay
+++ b/app/boards/shields/hillside_view/hillside_view_right.overlay
@@ -10,6 +10,10 @@
   col-offset = <6>;
 };
 
+&five_column_transform {
+    col-offset = <6>;
+};
+
 &kscan0 {
   col-gpios
     = <&pro_micro 10 GPIO_ACTIVE_HIGH>


### PR DESCRIPTION
Was wondering why I had truly bizarre, yet consistently off by the same number of columns, output coming from my right side after setting [this config](https://github.com/klardotsh/zmk-config/blob/3276f20657c89860a31c29bb4fd5c61e223d9863/config/hillside_view.keymap#L14-L16), it turns out only the full 6x3 was setting column offset in the device tree. This is a cherry-pick of that fix without the rest of my rebase noise in my fork. Cheers!